### PR TITLE
feat: add mock trigger callbacks, add mockRequestAccounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ testingUtils.mockChainChanged("0x3");
 // Simulate a change of account to 0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf
 testingUtils.mockAccountsChanged(["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"]);
 ```
+- `mockRequestAccounts`: allows to mock the connection request in the case of MetaMask
+```TypeScript
+// Mock the next request to eth_requestAccounts as 0x138071e4e810f34265bd833be9c5dd96f01bd8a5
+testingUtils.mockRequestAccounts(["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"]);
+```
 
 Additionally, the `generateContractUtils` is exposed from the setup and allows to generate high level utils for contract interactions based on their ABI.
 ```TypeScript

--- a/example/README.md
+++ b/example/README.md
@@ -17,7 +17,8 @@ npm install
 npm test
 ```
 
-There are two tests:
+There are three tests:
+- `app.test.tsx`: about connection with MetaMask eth_requestAccounts
 - `header.test.tsx`: about account and network display
 - `contract-box.test.tsx`: about contract interaction
 

--- a/example/src/__test__/app.test.tsx
+++ b/example/src/__test__/app.test.tsx
@@ -1,11 +1,12 @@
-import { render, screen, waitForElementToBeRemoved } from "@testing-library/react";
+import { render, screen, waitFor, waitForElementToBeRemoved } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "App";
+import { ABI } from "constants/storage-contract";
 import { setupEthTesting } from "../../../src";
 
 describe("App", () => {
     let originalEthereum: any;
-    const { provider, testingUtils } = setupEthTesting({
+    const { provider, testingUtils, generateContractUtils } = setupEthTesting({
         providerType: "MetaMask",
     });
 
@@ -22,10 +23,22 @@ describe("App", () => {
         testingUtils.clearAllMocks();
     });
 
-    test("user is able to connect by clicking on the connect button", async () => {
+    test("user is able to connect by clicking on the connect button, the wallet informations are shown", async () => {
+        const contractTestingUtils = generateContractUtils(ABI);
+
+        // Start with no accounts - the wallet is not connected
         testingUtils.mockAccounts([]);
-        testingUtils.mockChainId("0x1");
-        testingUtils.mockRequestAccounts(["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"]);
+
+        // After the eth_requestAccounts has finished, the chain will be 0x1, the account will be 0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf and the call to the `value` method will resolved with 100
+        testingUtils.mockRequestAccounts(
+            ["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"],
+            {
+                chainId: "0x1",
+                triggerCallback: () => {
+                    contractTestingUtils.mockCall("value", ["100"]);
+                }
+            }
+        );
 
         render(<App />);
 
@@ -33,5 +46,25 @@ describe("App", () => {
         userEvent.click(connectButton);
 
         await waitForElementToBeRemoved(() => screen.getByRole("button", { name: /connect/i }));
+
+        const accountElement = screen.getByText(/account/i);
+        const chainIdElement = screen.getByText(/chain id/i);
+
+        expect(accountElement).toHaveTextContent("Account:");
+        expect(chainIdElement).toHaveTextContent("Chain ID:");
+
+        const contractBoxValueElement = screen.getByText(/current value/i);
+        expect(contractBoxValueElement).toHaveTextContent("Current value:");
+
+        await waitFor(() => {
+            expect(accountElement).toHaveTextContent(
+              "Account: 0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"
+            );
+            expect(chainIdElement).toHaveTextContent("Chain ID: 0x1");
+        });
+
+        await waitFor(() => {
+            expect(contractBoxValueElement).toHaveTextContent("Current value: 100");
+        });
     })
 })

--- a/example/src/__test__/app.test.tsx
+++ b/example/src/__test__/app.test.tsx
@@ -23,13 +23,16 @@ describe("App", () => {
         testingUtils.clearAllMocks();
     });
 
-    test("user is able to connect by clicking on the connect button, the wallet informations are shown", async () => {
+    test("user is able to connect by clicking on the connect button, the wallet informations and smart contract values are shown", async () => {
         const contractTestingUtils = generateContractUtils(ABI);
 
         // Start with no accounts - the wallet is not connected
         testingUtils.mockAccounts([]);
 
-        // After the eth_requestAccounts has finished, the chain will be 0x1, the account will be 0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf and the call to the `value` method will resolved with 100
+        // After the eth_requestAccounts has resolved
+        // - the account will be "0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf",
+        // - the chain will be "0x1",
+        // - the call to the `value` method of the smart contract will resolved with 100
         testingUtils.mockRequestAccounts(
             ["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"],
             {

--- a/example/src/__test__/app.test.tsx
+++ b/example/src/__test__/app.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitForElementToBeRemoved } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "App";
+import { setupEthTesting } from "../../../src";
+
+describe("App", () => {
+    let originalEthereum: any;
+    const { provider, testingUtils } = setupEthTesting({
+        providerType: "MetaMask",
+    });
+
+    beforeAll(() => {
+        originalEthereum = (global.window as any).ethereum;
+        (global.window as any).ethereum = provider;
+    });
+
+    afterAll(() => {
+        (global.window as any).ethereum = originalEthereum;
+    });
+
+    afterEach(() => {
+        testingUtils.clearAllMocks();
+    });
+
+    test("user is able to connect by clicking on the connect button", async () => {
+        testingUtils.mockAccounts([]);
+        testingUtils.mockChainId("0x1");
+        testingUtils.mockRequestAccounts(["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"]);
+
+        render(<App />);
+
+        const connectButton = screen.getByRole("button", { name: /connect/i });
+        userEvent.click(connectButton);
+
+        await waitForElementToBeRemoved(() => screen.getByRole("button", { name: /connect/i }));
+    })
+})

--- a/example/src/pages/homepage/index.tsx
+++ b/example/src/pages/homepage/index.tsx
@@ -3,11 +3,14 @@ import { EthersContractBox, Web3JsContractBox } from "components/contract-box";
 import "./homepage.css";
 
 function Homepage() {
+  const showEthersContractBox = Math.floor(Math.random()) * 1000 % 2 === 0
   return (
     <div className="homepage">
       <Header />
-      <EthersContractBox />
-      <Web3JsContractBox />
+      {showEthersContractBox
+        ? <EthersContractBox />
+        : <Web3JsContractBox />
+      }
     </div>
   );
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -4,6 +4,7 @@ import { WalletConnectProvider } from "./wallet-connect";
 import { Provider } from "./provider";
 import { MockManager } from "./mock-manager";
 import { ContractUtils } from "./contract-utils";
+import { MockOptions } from "./types";
 
 type SetupOptions = {
   providerType: "MetaMask" | "WalletConnect" | "default";
@@ -40,6 +41,25 @@ export function setupEthTesting(options: SetupOptions = defaultSetupOptions) {
     mockManager.emit("accountsChanged", newAccounts);
   };
 
+
+  /**
+   * Mock the next eth_requestAccounts request
+   * @param accountsOrError Resolved accounts or rejected error
+   * @param mockOptions Mock options
+   * @example
+   * ```ts
+   * // The next eth_requestAccounts request will return the array of address
+   * testingUtils.mockRequestAccounts(["0x138071e4e810f34265bd833be9c5dd96f01bd8a5"]);
+   * ...
+   * // The next eth_requestAccounts request will fail with the error
+   * const error = { code: -32002 };
+   * testingUtils.mockRequestAccounts(error, { shouldThrow: true });
+   * ```
+   */
+  const mockRequestAccounts = (accountsOrError: unknown, mockOptions?: MockOptions) => {
+    mockManager.mockRequest("eth_requestAccounts", accountsOrError, mockOptions);
+  };
+
   const generateContractUtils = (abi: JsonFragment[]) =>
     new ContractUtils(mockManager, abi);
 
@@ -50,6 +70,7 @@ export function setupEthTesting(options: SetupOptions = defaultSetupOptions) {
       mockAccounts,
       mockChainChanged,
       mockAccountsChanged,
+      mockRequestAccounts,
       clearAllMocks: mockManager.clearAllMocks.bind(
         mockManager
       ) as MockManager["clearAllMocks"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type MockOptions = {
   shouldThrow?: boolean;
   timeout?: number;
   condition?: (params: unknown[]) => boolean;
+  triggerCallback?: (data?: unknown, params?: unknown[]) => void
 };
 
 export type MockRequest = {


### PR DESCRIPTION
## Summary

Trigger callbacks have been added to the mocks. It allows to trigger a callback function once the mock has been consumed. The goal is to allow developers to mock things in a dynamic way instead of having to set in stone the mocks at the start of the tests.

The `mockRequestAccounts` has been added at the high level utils. It allows to mock the MetaMask `eth_requestAccounts` and automatically set up mocks for the `eth_accounts` and optionally for the `eth_chainId` once the `eth_requestAccounts` mock has been consumed.

Resolves #10 