### PR TITLE
feat: add legacy send method for MetaMask provider

### DIFF
--- a/examples/react-apps/package-lock.json
+++ b/examples/react-apps/package-lock.json
@@ -17,6 +17,8 @@
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.13",
         "@walletconnect/web3-provider": "^1.7.3",
+        "@web3-react/core": "6.1.9",
+        "@web3-react/injected-connector": "6.0.7",
         "ethers": "^5.6.6",
         "install": "^0.13.0",
         "npm": "^8.5.2",
@@ -64,7 +66,7 @@
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-hooks": "^4.2.0",
-        "eslint-plugin-testing-library": "^4.12.0",
+        "eslint-plugin-testing-library": "^3.9.0",
         "husky": "^4.3.7",
         "lint-staged": "^10.5.3",
         "prettier": "^2.2.1",
@@ -28795,6 +28797,44 @@
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.0"
       }
+    },
+    "node_modules/@web3-react/abstract-connector": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/abstract-connector/-/abstract-connector-6.0.7.tgz",
+      "integrity": "sha512-RhQasA4Ox8CxUC0OENc1AJJm8UTybu/oOCM61Zjg6y0iF7Z0sqv1Ai1VdhC33hrQpA8qSBgoXN9PaP8jKmtdqg==",
+      "dependencies": {
+        "@web3-react/types": "^6.0.7"
+      }
+    },
+    "node_modules/@web3-react/core": {
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@web3-react/core/-/core-6.1.9.tgz",
+      "integrity": "sha512-P877DslsbAkWIlMANpWiK7pCvNwlz0kJC0EGckuVh0wlA23J4UnFxq6xyOaxkxaDCu14rA/tAO0NbwjcXTQgSA==",
+      "dependencies": {
+        "@ethersproject/keccak256": "^5.0.0-beta.130",
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-invariant": "^1.0.6",
+        "tiny-warning": "^1.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@web3-react/injected-connector": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/injected-connector/-/injected-connector-6.0.7.tgz",
+      "integrity": "sha512-Y7aJSz6pg+MWKtvdyuqyy6LWuH+4Tqtph1LWfiyVms9II9ar/9B/de4R8wh4wjg91wmHkU+D75yP09E/Soh2RA==",
+      "dependencies": {
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "node_modules/@web3-react/types": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/types/-/types-6.0.7.tgz",
+      "integrity": "sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -59059,6 +59099,16 @@
       "version": "0.3.0",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "dev": true,
@@ -73880,6 +73930,41 @@
         "@walletconnect/window-getters": "^1.0.0"
       }
     },
+    "@web3-react/abstract-connector": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/abstract-connector/-/abstract-connector-6.0.7.tgz",
+      "integrity": "sha512-RhQasA4Ox8CxUC0OENc1AJJm8UTybu/oOCM61Zjg6y0iF7Z0sqv1Ai1VdhC33hrQpA8qSBgoXN9PaP8jKmtdqg==",
+      "requires": {
+        "@web3-react/types": "^6.0.7"
+      }
+    },
+    "@web3-react/core": {
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@web3-react/core/-/core-6.1.9.tgz",
+      "integrity": "sha512-P877DslsbAkWIlMANpWiK7pCvNwlz0kJC0EGckuVh0wlA23J4UnFxq6xyOaxkxaDCu14rA/tAO0NbwjcXTQgSA==",
+      "requires": {
+        "@ethersproject/keccak256": "^5.0.0-beta.130",
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-invariant": "^1.0.6",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "@web3-react/injected-connector": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/injected-connector/-/injected-connector-6.0.7.tgz",
+      "integrity": "sha512-Y7aJSz6pg+MWKtvdyuqyy6LWuH+4Tqtph1LWfiyVms9II9ar/9B/de4R8wh4wjg91wmHkU+D75yP09E/Soh2RA==",
+      "requires": {
+        "@web3-react/abstract-connector": "^6.0.7",
+        "@web3-react/types": "^6.0.7",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "@web3-react/types": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@web3-react/types/-/types-6.0.7.tgz",
+      "integrity": "sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "requires": {
@@ -77298,7 +77383,7 @@
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-hooks": "^4.2.0",
-        "eslint-plugin-testing-library": "^4.12.0",
+        "eslint-plugin-testing-library": "^3.9.0",
         "ethers": "^5.5.4",
         "husky": "^4.3.7",
         "lint-staged": "^10.5.3",
@@ -103004,6 +103089,16 @@
     },
     "timsort": {
       "version": "0.3.0"
+    },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/examples/react-apps/package.json
+++ b/examples/react-apps/package.json
@@ -11,6 +11,8 @@
     "hardhat:node": "hardhat node"
   },
   "dependencies": {
+    "@web3-react/core": "6.1.9",
+    "@web3-react/injected-connector": "6.0.7",
     "@tanstack/react-location": "^3.6.1",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",

--- a/examples/react-apps/src/App.tsx
+++ b/examples/react-apps/src/App.tsx
@@ -14,6 +14,7 @@ import {
 } from "pages/contract-interactions/contract-box";
 import EnsStuff from "pages/ens";
 import WalletConnectConnection from "pages/wallet-connect-connection";
+import Web3ReactPage from "pages/web3-react";
 
 const routes: Route[] = [
   {
@@ -31,6 +32,7 @@ const routes: Route[] = [
     ],
   },
   { path: "ens", element: <EnsStuff /> },
+  { path: "web3-react", element: <Web3ReactPage /> },
 ];
 
 const location = new ReactLocation();
@@ -44,6 +46,7 @@ function App() {
         <Link to="wallet-connect-connection">Wallet Connect Connection</Link>{" "}
         <Link to="contract-interactions">Contract interaction</Link>{" "}
         <Link to="ens">ENS</Link>
+        <Link to="web3-react">Web3 React</Link>
       </div>
       <hr />
       <Outlet />

--- a/examples/react-apps/src/pages/web3-react/__test__/web3-react-page.test.tsx
+++ b/examples/react-apps/src/pages/web3-react/__test__/web3-react-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { generateTestingUtils } from "eth-testing";
 import Web3ReactPage from "..";

--- a/examples/react-apps/src/pages/web3-react/__test__/web3-react-page.test.tsx
+++ b/examples/react-apps/src/pages/web3-react/__test__/web3-react-page.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { generateTestingUtils } from "eth-testing";
+import Web3ReactPage from "..";
+
+describe("Web3 React app", () => {
+    let originalEthereum: any;
+    const testingUtils = generateTestingUtils({
+        providerType: "MetaMask",
+    });
+
+    beforeAll(() => {
+        originalEthereum = global.window.ethereum;
+        global.window.ethereum = testingUtils.getProvider();
+    });
+
+    afterEach(() => {
+        testingUtils.clearAllMocks();
+      });
+
+    afterAll(() => {
+        global.window.ethereum = originalEthereum;
+    });
+    test("User should be able to see its address after connection", async () => {
+        testingUtils.mockNotConnectedWallet();
+
+        testingUtils.mockRequestAccounts(
+            ["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"],
+            {
+              balance: "0x1bc16d674ec80000",
+            }
+          );
+
+        render(<Web3ReactPage />);
+
+        expect(screen.queryByText(/account/i)).not.toBeInTheDocument();
+
+        userEvent.click(screen.getByRole('button'));
+
+        await screen.findByText(/account: 0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf/i);
+    })
+})

--- a/examples/react-apps/src/pages/web3-react/index.tsx
+++ b/examples/react-apps/src/pages/web3-react/index.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { ethers } from "ethers";
+import { useWeb3React, Web3ReactProvider } from "@web3-react/core";
+import { InjectedConnector } from "@web3-react/injected-connector";
+
+const connector = new InjectedConnector({});
+
+function Web3ReactPage() {
+    return (
+        <Web3ReactProvider getLibrary={(p) => new ethers.providers.Web3Provider(p)}>
+            <Example />
+        </Web3ReactProvider>
+    )
+}
+
+function Example() {
+    const { activate, account } = useWeb3React();
+
+    return (
+        <div>
+            <button
+                onClick={() => activate(connector)}
+            >
+                Connect
+            </button>
+            {account ? <div>Account: {account}</div> : null}
+        </div>
+    )
+}
+
+export default Web3ReactPage;

--- a/examples/react-apps/src/pages/web3-react/index.tsx
+++ b/examples/react-apps/src/pages/web3-react/index.tsx
@@ -14,7 +14,18 @@ function Web3ReactPage() {
 }
 
 function Example() {
-    const { activate, account } = useWeb3React();
+    const { activate, account, library } = useWeb3React();
+
+    const [signature, setSignature] = React.useState("");
+
+    const sign = async () => {
+        if (!library) {
+            throw new Error("Oh no, it's broken :(")
+        }
+        const signer = library.getSigner();
+        const signature = await signer.signMessage("hello");
+        setSignature(signature);
+    }
 
     return (
         <div>
@@ -24,6 +35,15 @@ function Example() {
                 Connect
             </button>
             {account ? <div>Account: {account}</div> : null}
+            {account
+                ? (
+                    <div>
+                        <button onClick={sign}>Sign message</button>
+                        {signature ? <div>Signature: {signature}</div> : null}
+                    </div>
+                )
+                : null
+            }
         </div>
     )
 }

--- a/src/providers/metamask.ts
+++ b/src/providers/metamask.ts
@@ -9,4 +9,18 @@ class MockInternalMetaMask {
 export class MetaMaskProvider extends Provider {
   public isMetaMask = true;
   public _metamask = new MockInternalMetaMask();
+
+  public send(
+    methodOrPayload: string | { method: string; params: unknown[] },
+    params?: unknown[]
+  ) {
+    if (typeof methodOrPayload === "string") {
+      return this.request({ method: methodOrPayload, params });
+    } else {
+      return this.request({
+        method: methodOrPayload.method,
+        params: methodOrPayload.params,
+      });
+    }
+  }
 }


### PR DESCRIPTION
## Summary

The legacy `send` method has been added to the MetaMask provider. It fixes the connection issue with `web3-react`.

A short example has been made with `web3-react`.

Resolves #47 