### PR TITLE
feat: use abitype for event and method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ testingUtils.mockRequestAccounts(["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"])
 Most of the application interacts with deployed contracts, interactions are generally more complex with contracts, hence a dedicated object has been created for it.
 
 The testing utils expose a `generateContractUtils` method, it allows to generate high level utils for contract interactions based on their ABI.
+
+It is advised to *freeze* the ABI using `as const` [feature](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#readonly-and-const) of TypeScript. By doing so, types will be generated for event and method names when using the contract testing utils. Refer to [ABIType](https://github.com/wagmi-dev/abitype) for additional informations.
 ```ts
-const abi = [...];
+const abi = [...] as const;
 // An address may be optionally given as second argument, advised in case of multiple similar contracts
 const contractTestingUtils = testingUtils.generateContractUtils(abi);
 ```

--- a/examples/react-apps/package-lock.json
+++ b/examples/react-apps/package-lock.json
@@ -50,6 +50,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "abitype": "^0.1.6",
         "ethers": "^5.5.4"
       },
       "devDependencies": {
@@ -77373,6 +77374,7 @@
         "@types/jest": "^27.5.0",
         "@typescript-eslint/eslint-plugin": "^4.12.0",
         "@typescript-eslint/parser": "^4.12.0",
+        "abitype": "^0.1.6",
         "babel-eslint": "^10.1.0",
         "eslint": "^7.17.0",
         "eslint-config-prettier": "^7.1.0",

--- a/examples/react-apps/package.json
+++ b/examples/react-apps/package.json
@@ -11,8 +11,6 @@
     "hardhat:node": "hardhat node"
   },
   "dependencies": {
-    "@web3-react/core": "6.1.9",
-    "@web3-react/injected-connector": "6.0.7",
     "@tanstack/react-location": "^3.6.1",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
@@ -22,6 +20,8 @@
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.13",
     "@walletconnect/web3-provider": "^1.7.3",
+    "@web3-react/core": "6.1.9",
+    "@web3-react/injected-connector": "6.0.7",
     "ethers": "^5.6.6",
     "install": "^0.13.0",
     "npm": "^8.5.2",

--- a/examples/react-apps/src/constants/storage-contract.ts
+++ b/examples/react-apps/src/constants/storage-contract.ts
@@ -1,4 +1,4 @@
-export const ABI = [
+export const ABI = <const>[
   {
     inputs: [],
     stateMutability: "nonpayable",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1-semantic-release",
       "license": "MIT",
       "dependencies": {
+        "abitype": "^0.1.6",
         "ethers": "^5.5.4"
       },
       "devDependencies": {
@@ -2761,6 +2762,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.1.6.tgz",
+      "integrity": "sha512-cdOzP4mi5pH/N3o5ly8wlw7HIqdFJVkS0RSw5p7BTvwB1gFXOqPlQJ/ZKTSCsGqd8EITJcpNuZ2h7hPX2mKECA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "engines": {
+        "node": ">=16",
+        "pnpm": ">=7"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7.4"
       }
     },
     "node_modules/acorn": {
@@ -12663,10 +12682,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true,
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14925,6 +14943,12 @@
         "@typescript-eslint/types": "4.29.2",
         "eslint-visitor-keys": "^2.0.0"
       }
+    },
+    "abitype": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.1.6.tgz",
+      "integrity": "sha512-cdOzP4mi5pH/N3o5ly8wlw7HIqdFJVkS0RSw5p7BTvwB1gFXOqPlQJ/ZKTSCsGqd8EITJcpNuZ2h7hPX2mKECA==",
+      "requires": {}
     },
     "acorn": {
       "version": "7.4.1",
@@ -22290,10 +22314,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "uglify-js": {
       "version": "3.14.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "format": "prettier src examples/react-apps/src --write"
   },
   "dependencies": {
+    "abitype": "^0.1.6",
     "ethers": "^5.5.4"
   },
   "devDependencies": {

--- a/src/testing-utils/contract-utils.ts
+++ b/src/testing-utils/contract-utils.ts
@@ -128,7 +128,6 @@ export class ContractUtils<
     functionName: TAbi extends AbiType
       ? ExtractAbiFunctionNames<TAbi, "nonpayable" | "payable">
       : string,
-    // functionName: ExtractAbiFunctionNames<TAbi, "nonpayable" | "payable">,
     txOptions: TxOptions = {},
     mockOptions: MockOptions = {}
   ) {

--- a/src/testing-utils/contract-utils.ts
+++ b/src/testing-utils/contract-utils.ts
@@ -64,7 +64,6 @@ export class ContractUtils<
    * ```
    */
   public mockCall(
-    // functionName: ExtractAbiFunctionNames<TAbi, "view" | "pure">,
     functionName: TAbi extends AbiType
       ? ExtractAbiFunctionNames<TAbi, "view" | "pure">
       : string,
@@ -265,7 +264,6 @@ export class ContractUtils<
    * ```
    */
   public mockGetLogs(
-    // eventName: ExtractAbiEventNames<TAbi>,
     eventName: TAbi extends AbiType ? ExtractAbiEventNames<TAbi> : string,
     allValues: unknown[][]
   ) {
@@ -314,7 +312,6 @@ export class ContractUtils<
    * ```
    */
   public mockEmitLog(
-    // eventName: ExtractAbiEventNames<TAbi>,
     eventName: TAbi extends AbiType ? ExtractAbiEventNames<TAbi> : string,
     values: unknown[],
     subscriptionId?: string,
@@ -385,7 +382,6 @@ export class ContractUtils<
    * @returns The log for the event
    */
   public generateMockLog(
-    // eventName: ExtractAbiEventNames<TAbi>,
     eventName: TAbi extends AbiType ? ExtractAbiEventNames<TAbi> : string,
     values: unknown[],
     logOverrides?: Partial<Log>

--- a/src/testing-utils/contract-utils.ts
+++ b/src/testing-utils/contract-utils.ts
@@ -1,5 +1,5 @@
 import { ethers, EventFilter } from "ethers";
-import { Interface, JsonFragment } from "@ethersproject/abi";
+import { Interface, JsonFragment, Fragment } from "@ethersproject/abi";
 import { BigNumber } from "@ethersproject/bignumber";
 import { Transaction } from "@ethersproject/transactions";
 import { ContractReceipt } from "@ethersproject/contracts";
@@ -27,8 +27,13 @@ type TxOptions = {
 
 type ConditionCache = Record<string, MockCondition>;
 
+type AbiType = ReadonlyArray<AbiEvent | AbiFunction | AbiError>;
+
 export class ContractUtils<
-  TAbi extends readonly (AbiEvent | AbiFunction | AbiError)[]
+  TAbi extends readonly (
+    | (JsonFragment | Fragment)
+    | (AbiEvent | AbiFunction | AbiError)
+  )[]
 > {
   private mockManager: MockManager;
   private contractInterface: Interface;
@@ -59,7 +64,10 @@ export class ContractUtils<
    * ```
    */
   public mockCall(
-    functionName: ExtractAbiFunctionNames<TAbi, "view" | "pure">,
+    // functionName: ExtractAbiFunctionNames<TAbi, "view" | "pure">,
+    functionName: TAbi extends AbiType
+      ? ExtractAbiFunctionNames<TAbi, "view" | "pure">
+      : string,
     values: readonly any[] | undefined,
     callOptions: CallOptions = {},
     mockOptions: MockOptions = {}
@@ -118,7 +126,10 @@ export class ContractUtils<
    * ```
    */
   public mockTransaction(
-    functionName: ExtractAbiFunctionNames<TAbi, "nonpayable" | "payable">,
+    functionName: TAbi extends AbiType
+      ? ExtractAbiFunctionNames<TAbi, "nonpayable" | "payable">
+      : string,
+    // functionName: ExtractAbiFunctionNames<TAbi, "nonpayable" | "payable">,
     txOptions: TxOptions = {},
     mockOptions: MockOptions = {}
   ) {
@@ -254,7 +265,8 @@ export class ContractUtils<
    * ```
    */
   public mockGetLogs(
-    eventName: ExtractAbiEventNames<TAbi>,
+    // eventName: ExtractAbiEventNames<TAbi>,
+    eventName: TAbi extends AbiType ? ExtractAbiEventNames<TAbi> : string,
     allValues: unknown[][]
   ) {
     const blockNumberMock =
@@ -302,7 +314,8 @@ export class ContractUtils<
    * ```
    */
   public mockEmitLog(
-    eventName: ExtractAbiEventNames<TAbi>,
+    // eventName: ExtractAbiEventNames<TAbi>,
+    eventName: TAbi extends AbiType ? ExtractAbiEventNames<TAbi> : string,
     values: unknown[],
     subscriptionId?: string,
     logOverrides?: Partial<Log>
@@ -372,7 +385,8 @@ export class ContractUtils<
    * @returns The log for the event
    */
   public generateMockLog(
-    eventName: ExtractAbiEventNames<TAbi>,
+    // eventName: ExtractAbiEventNames<TAbi>,
+    eventName: TAbi extends AbiType ? ExtractAbiEventNames<TAbi> : string,
     values: unknown[],
     logOverrides?: Partial<Log>
   ): Log {

--- a/src/testing-utils/ens-utils/constants.ts
+++ b/src/testing-utils/ens-utils/constants.ts
@@ -3,7 +3,7 @@ export const ENS_REGISTRY_WITH_FALLBACK_ADDRESS =
 export const PUBLIC_RESOLVER_ADDRESS =
   "0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41";
 
-export const ENS_REGISTRY_WITH_FALLBACK_ABI = [
+export const ENS_REGISTRY_WITH_FALLBACK_ABI = <const>[
   {
     inputs: [{ internalType: "contract ENS", name: "_old", type: "address" }],
     payable: false,
@@ -236,7 +236,7 @@ export const ENS_REGISTRY_WITH_FALLBACK_ABI = [
   },
 ];
 
-export const PUBLIC_RESOLVER_ABI = [
+export const PUBLIC_RESOLVER_ABI = <const>[
   {
     inputs: [{ internalType: "contract ENS", name: "_ens", type: "address" }],
     payable: false,

--- a/src/testing-utils/ens-utils/index.ts
+++ b/src/testing-utils/ens-utils/index.ts
@@ -9,8 +9,8 @@ import {
 } from "./constants";
 
 export class EnsUtils {
-  private ensRegistryWithFallbackUtils: ContractUtils;
-  private publicResolverUtils: ContractUtils;
+  private ensRegistryWithFallbackUtils;
+  private publicResolverUtils;
 
   constructor(mockManager: MockManager) {
     this.ensRegistryWithFallbackUtils = new ContractUtils(
@@ -66,7 +66,7 @@ export class EnsUtils {
       persistent: true,
     });
     this.publicResolverUtils.mockCall(
-      "addr(bytes32)",
+      "addr(bytes32)" as any,
       [ethers.constants.AddressZero],
       undefined,
       { persistent: true }
@@ -112,9 +112,14 @@ export class EnsUtils {
     this.publicResolverUtils.mockCall("supportsInterface", [false], undefined, {
       persistent: true,
     });
-    this.publicResolverUtils.mockCall("addr(bytes32)", [address], callValues, {
-      persistent: true,
-    });
+    this.publicResolverUtils.mockCall(
+      "addr(bytes32)" as any,
+      [address],
+      callValues,
+      {
+        persistent: true,
+      }
+    );
   }
 
   /**

--- a/src/testing-utils/testing-utils.ts
+++ b/src/testing-utils/testing-utils.ts
@@ -4,7 +4,7 @@ import { ContractUtils } from "./contract-utils";
 import { MockCondition, MockOptions } from "../types";
 import { Provider } from "../providers";
 import { EnsUtils } from "./ens-utils";
-import { AbiError, AbiEvent, AbiFunction, narrow } from "abitype";
+import { AbiError, AbiEvent, AbiFunction } from "abitype";
 import { Fragment } from "ethers/lib/utils";
 import { JsonFragment } from "@ethersproject/abi";
 
@@ -326,16 +326,8 @@ export class TestingUtils {
       | AbiFunction
       | AbiError
     )[]
-  >(
-    abi: TAbi,
-    // abi: readonly (Fragment | JsonFragment | (AbiEvent | AbiFunction | AbiError))[],
-    contractAddress?: string
-  ) {
-    return new ContractUtils<TAbi>(
-      this.mockManager,
-      narrow(abi as any),
-      contractAddress
-    );
+  >(abi: TAbi, contractAddress?: string) {
+    return new ContractUtils<TAbi>(this.mockManager, abi, contractAddress);
   }
 
   /**

--- a/src/testing-utils/testing-utils.ts
+++ b/src/testing-utils/testing-utils.ts
@@ -4,7 +4,9 @@ import { ContractUtils } from "./contract-utils";
 import { MockCondition, MockOptions } from "../types";
 import { Provider } from "../providers";
 import { EnsUtils } from "./ens-utils";
-import { AbiError, AbiEvent, AbiFunction } from "abitype";
+import { AbiError, AbiEvent, AbiFunction, narrow } from "abitype";
+import { Fragment } from "ethers/lib/utils";
+import { JsonFragment } from "@ethersproject/abi";
 
 export class LowLevelTestingUtils {
   private mockManager: MockManager;
@@ -316,11 +318,24 @@ export class TestingUtils {
    * const erc20TestingUtils = testingUtils.generateContractUtils(ERC20_ABI);
    * ```
    */
-  public generateContractUtils(
-    abi: readonly (AbiEvent | AbiFunction | AbiError)[],
+  public generateContractUtils<
+    TAbi extends readonly (
+      | Fragment
+      | JsonFragment
+      | AbiEvent
+      | AbiFunction
+      | AbiError
+    )[]
+  >(
+    abi: TAbi,
+    // abi: readonly (Fragment | JsonFragment | (AbiEvent | AbiFunction | AbiError))[],
     contractAddress?: string
   ) {
-    return new ContractUtils(this.mockManager, abi, contractAddress);
+    return new ContractUtils<TAbi>(
+      this.mockManager,
+      narrow(abi as any),
+      contractAddress
+    );
   }
 
   /**

--- a/src/testing-utils/testing-utils.ts
+++ b/src/testing-utils/testing-utils.ts
@@ -1,10 +1,10 @@
-import { Fragment, JsonFragment } from "@ethersproject/abi";
 import { ethers } from "ethers";
 import { MockManager } from "../mock-manager";
 import { ContractUtils } from "./contract-utils";
 import { MockCondition, MockOptions } from "../types";
 import { Provider } from "../providers";
 import { EnsUtils } from "./ens-utils";
+import { AbiError, AbiEvent, AbiFunction } from "abitype";
 
 export class LowLevelTestingUtils {
   private mockManager: MockManager;
@@ -317,7 +317,7 @@ export class TestingUtils {
    * ```
    */
   public generateContractUtils(
-    abi: (string | JsonFragment | Fragment)[],
+    abi: readonly (AbiEvent | AbiFunction | AbiError)[],
     contractAddress?: string
   ) {
     return new ContractUtils(this.mockManager, abi, contractAddress);


### PR DESCRIPTION
## Summary

[ABI Type](https://github.com/wagmi-dev/abitype) is imported.

The developer is encouraged to give a frozen ABI in order to enable strict typing for event and method names.