### PR TITLE
fix: allow string as abi

### DIFF
--- a/src/testing-utils/contract-utils.ts
+++ b/src/testing-utils/contract-utils.ts
@@ -32,10 +32,12 @@ type ConditionCache = Record<string, MockCondition>;
 type AbiType = ReadonlyArray<AbiEvent | AbiFunction | AbiError>;
 
 export class ContractUtils<
-  TAbi extends readonly (
-    | (JsonFragment | Fragment)
-    | (AbiEvent | AbiFunction | AbiError)
-  )[]
+  TAbi extends
+    | string
+    | readonly (
+        | (JsonFragment | Fragment)
+        | (AbiEvent | AbiFunction | AbiError)
+      )[]
 > {
   private mockManager: MockManager;
   private contractInterface: Interface;

--- a/src/testing-utils/testing-utils.ts
+++ b/src/testing-utils/testing-utils.ts
@@ -341,13 +341,9 @@ export class TestingUtils {
    * ```
    */
   public generateContractUtils<
-    TAbi extends readonly (
-      | Fragment
-      | JsonFragment
-      | AbiEvent
-      | AbiFunction
-      | AbiError
-    )[]
+    TAbi extends
+      | string
+      | readonly (Fragment | JsonFragment | AbiEvent | AbiFunction | AbiError)[]
   >(abi: TAbi, contractAddress?: string) {
     return new ContractUtils<TAbi>(this.mockManager, abi, contractAddress);
   }


### PR DESCRIPTION
## Summary

The abi in `generateContractUtils` can be given as `string`