### PR TITLE
feat: add coinbase provider, update verbose type

### DIFF
--- a/src/providers/coinbase.ts
+++ b/src/providers/coinbase.ts
@@ -1,0 +1,19 @@
+import { Provider } from "./provider";
+
+export class CoinbaseProvider extends Provider {
+  public isCoinbaseWallet = true;
+
+  public send(
+    methodOrPayload: string | { method: string; params: unknown[] },
+    params?: unknown[]
+  ) {
+    if (typeof methodOrPayload === "string") {
+      return this.request({ method: methodOrPayload, params });
+    } else {
+      return this.request({
+        method: methodOrPayload.method,
+        params: methodOrPayload.params,
+      });
+    }
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,4 @@
 export * from "./metamask";
 export * from "./provider";
 export * from "./wallet-connect";
+export * from "./coinbase";

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -7,15 +7,15 @@ type VerboseConfiguration = {
   dismissMocked?: boolean;
   dismissNotMocked?: boolean;
 };
-type Verbose = VerboseConfiguration;
+export type VerboseArgs = boolean | VerboseConfiguration;
 type ProviderConstructorArgs = {
-  verbose?: boolean | Verbose;
+  verbose?: VerboseArgs;
 };
 
 export class Provider extends EventEmitter {
   public requestMocks: Record<string, MockRequest[]> = {};
 
-  public verbose: Verbose;
+  public verbose: VerboseConfiguration;
 
   constructor({ verbose }: ProviderConstructorArgs) {
     super();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,9 +1,15 @@
-import { MetaMaskProvider, WalletConnectProvider, Provider } from "./providers";
+import {
+  MetaMaskProvider,
+  WalletConnectProvider,
+  Provider,
+  CoinbaseProvider,
+  VerboseArgs,
+} from "./providers";
 import { TestingUtils } from "./testing-utils";
 
 type GenerateOptions = {
-  providerType?: "MetaMask" | "WalletConnect" | "default";
-  verbose?: boolean;
+  providerType?: "MetaMask" | "WalletConnect" | "Coinbase" | "default";
+  verbose?: VerboseArgs;
 };
 
 const defaultGenerationOptions: GenerateOptions = {
@@ -14,7 +20,7 @@ const defaultGenerationOptions: GenerateOptions = {
 /**
  * Generate the testing utils associated with a mock provider
  * @param options.providerType Type of the provider to mock, default to `default`
- * @param options.verbose If true, the JSON-RPC request will be logged
+ * @param options.verbose Verbose configuration
  * @returns The testing utils for one provider
  */
 export function generateTestingUtils({
@@ -24,6 +30,8 @@ export function generateTestingUtils({
   const provider =
     providerType === "MetaMask"
       ? new MetaMaskProvider({ verbose })
+      : providerType === "Coinbase"
+      ? new CoinbaseProvider({ verbose })
       : providerType === "WalletConnect"
       ? new WalletConnectProvider({ verbose })
       : new Provider({ verbose });


### PR DESCRIPTION
## Summary

The Coinbase provider has been added. It is very similar to the MetaMask one but with the `isCoinbaseWallet` property set to `true`.

Additionally, the type of the verbose mode has been fixed.

Resolves #58 