### PR TITLE
feat: allow functional mock for mockCall

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,26 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contributing](#contributing)
+  - [Questions](#questions)
+  - [Reporting Issues](#reporting-issues)
+  - [Suggesting new features](#suggesting-new-features)
+  - [Development](#development)
+  - [Commit message conventions](#commit-message-conventions)
+    - [Commit Message Format](#commit-message-format)
+    - [Type](#type)
+    - [Scope](#scope)
+    - [Subject](#subject)
+    - [Body](#body)
+    - [Footer](#footer)
+    - [Example](#example)
+    - [Revert](#revert)
+  - [Pull requests](#pull-requests)
+  - [Releases](#releases)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Contributing
 
 ## Questions

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - [High levels mocks](#high-levels-mocks)
   - [Testing contract interactions](#testing-contract-interactions)
   - [Low levels mocks](#low-levels-mocks)
+  - [Mocking values using functions](#mocking-values-using-functions)
   - [Mock options](#mock-options)
   - [Verbose mode](#verbose-mode)
 - [Contributing :rocket:](#contributing-rocket)
@@ -277,6 +278,27 @@ testingUtils.lowLevel.emit("accountsChanged", ["0xf61B443A155b07D2b2cAeA2d99715d
 // Simulate 0x138071e4e810f34265bd833be9c5dd96f01bd8a5 as connected account
 testingUtils.lowLevel.mockRequest("eth_accounts", ["0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf"]);
 ```
+
+### Mocking values using functions
+
+A part of the mocking utilities allow to use functions returning or resolving the mocked values instead of directly specifying the mocked values. This functional form allows for arbitrary logic to run before returning the mocked values. It allows in particular to dynamically handle the mocked values based on the params or defer the response.
+
+```ts
+// Example extracted from #61 for deferred responses
+const mockContract = mockWalletConnect.generateContractUtils(ContractABI, CONTRACT_ADDRESS);
+const myFunctionDelay = new Deferred();
+mockContract.mockCall('someFunction', async (params: [callPayload: TransactionCallPayload, blockTag: string]) => {
+    await myFunctionDelay.promise;
+    return ["Example return value"]
+});
+
+// Later, cause the system under test to make the contract call
+// Then assert the in-progress state is correct
+// Finally, trigger the smart contract function to complete
+myFunctionDelay.resolve();
+```
+
+At the moment of writing, only the `mockCall` and the low level utils allow for functional mocking.
 
 ### Mock options
 

--- a/examples/react-apps/src/pages/contract-interactions/__tests__/contract-box-deffered.test.tsx
+++ b/examples/react-apps/src/pages/contract-interactions/__tests__/contract-box-deffered.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { generateTestingUtils } from "eth-testing";
+import { ABI } from "constants/storage-contract";
+import EthersContractBox from "../contract-box/ethers-contract-box";
+import Web3JsContractBox from "../contract-box/web3js-contract-box";
+
+class Deferred {
+  private res: ((value: unknown) => void) | undefined = undefined;
+  public promise;
+
+  constructor() {
+    const promise = new Promise((res) => {
+        this.res = res;
+    });
+    this.promise = promise;
+  }
+
+  public resolve() {
+    if (!this.res) {
+        throw new Error("Nothing to resolve")
+    }
+    this.res(null);
+  }
+}
+
+describe("ContractBox Deffered calls", () => {
+  let originalEthereum: any;
+  const testingUtils = generateTestingUtils({
+    providerType: "MetaMask",
+  });
+
+  beforeAll(() => {
+    originalEthereum = global.window.ethereum;
+    global.window.ethereum = testingUtils.getProvider();
+  });
+
+  afterAll(() => {
+    global.window.ethereum = originalEthereum;
+  });
+
+  beforeEach(() => {
+    testingUtils.mockConnectedWallet([
+      "0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf",
+    ]);
+  });
+
+  afterEach(() => {
+    testingUtils.clearAllMocks();
+  });
+
+  test(`ethers - the value of the contract is displayed and up to date`, async () => {
+    const myFunctionDelay = new Deferred();
+
+    const contractTestingUtils = testingUtils.generateContractUtils(ABI);
+
+    contractTestingUtils.mockCall("value", async () => {
+      await myFunctionDelay.promise
+      return ["100"]
+    });
+    contractTestingUtils.mockGetLogs("ValueUpdated", [["0"], ["12"]]);
+
+    render(<EthersContractBox />);
+
+    const valueElement = screen.getByText(/current value/i);
+    expect(valueElement).toHaveTextContent("Current value:");
+
+    await myFunctionDelay.resolve();
+
+    await waitFor(() => {
+      expect(valueElement).toHaveTextContent("Current value: 100");
+    });
+
+    expect(screen.getByText(/previous value: 0/i)).toBeInTheDocument();
+    expect(screen.getByText(/previous value: 12/i)).toBeInTheDocument();
+  });
+
+  test(`web3js - the value of the contract is displayed and up to date`, async () => {
+    const myFunctionDelay = new Deferred();
+
+    const contractTestingUtils = testingUtils.generateContractUtils(ABI);
+
+    contractTestingUtils.mockCall("value", async () => {
+      await myFunctionDelay.promise
+      return ["100"]
+    });
+    contractTestingUtils.mockGetLogs("ValueUpdated", [["0"], ["12"]]);
+
+    const subscriptionID = "0x123";
+    testingUtils.mockSubscribe(subscriptionID);
+
+    render(<Web3JsContractBox />);
+
+    const valueElement = screen.getByText(/current value/i);
+    expect(valueElement).toHaveTextContent("Current value:");
+
+    await myFunctionDelay.resolve();
+
+    await waitFor(() => {
+      expect(valueElement).toHaveTextContent("Current value: 100");
+    });
+
+    expect(screen.getByText(/previous value: 0/i)).toBeInTheDocument();
+    expect(screen.getByText(/previous value: 12/i)).toBeInTheDocument();
+  });
+});

--- a/src/mock-manager.ts
+++ b/src/mock-manager.ts
@@ -52,7 +52,9 @@ export class MockManager {
           | Extract<JsonRPCMethod, { method: TMethod }>["response"]
           | ((
               params: Extract<JsonRPCMethod, { method: TMethod }>["params"]
-            ) => Extract<JsonRPCMethod, { method: TMethod }>["response"]),
+            ) =>
+              | Promise<Extract<JsonRPCMethod, { method: TMethod }>["response"]>
+              | Extract<JsonRPCMethod, { method: TMethod }>["response"]),
     mockOptions = defaultMockOptions as TOptions
   ) {
     const { condition, persistent } = mockOptions;

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,4 +1,3 @@
-// import { EventEmitter } from "node:events";
 import EventEmitter from "events";
 import { MockRequest } from "../types";
 

--- a/src/testing-utils/testing-utils.ts
+++ b/src/testing-utils/testing-utils.ts
@@ -64,7 +64,9 @@ export class LowLevelTestingUtils {
           | Extract<JsonRPCMethod, { method: TMethod }>["response"]
           | ((
               params: Extract<JsonRPCMethod, { method: TMethod }>["params"]
-            ) => Extract<JsonRPCMethod, { method: TMethod }>["response"]),
+            ) =>
+              | Promise<Extract<JsonRPCMethod, { method: TMethod }>["response"]>
+              | Extract<JsonRPCMethod, { method: TMethod }>["response"]),
     mockOptions = defaultMockOptions as TOptions
   ) {
     this.mockManager.mockRequest<JsonRPCMethodName, MockOptions>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type MockOptions = {
 
 export type MockRequest = {
   method: string;
-  data: unknown | ((params: unknown[]) => unknown);
+  data: unknown | ((params: unknown[]) => Promise<unknown>);
 } & MockOptions;
 
 export type LiteralUnion<T extends U, U = string> =


### PR DESCRIPTION
## Summary

The `mockCall` utils now allows for functional mocking.

The types have been updated in order to properly take into account functional mocks.

A test with deferred calls have been added.

The `Mocking values with functions` part has been added in the README.

Resolves #61 