### PR TITLE
WIP: feat: implement EthereumProvider for WalletConnect V2

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,5 @@
 export * from "./metamask";
 export * from "./provider";
 export * from "./wallet-connect";
+export * from "./wallet-connect-ethereum-provider";
 export * from "./coinbase";

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -11,6 +11,7 @@ export type ProviderType =
   | "MetaMask"
   | "Coinbase"
   | "WalletConnect"
+  | "WalletConnect-EthereumProvider"
   | "default";
 
 type ProviderConstructorArgs = {
@@ -35,6 +36,13 @@ export class Provider extends EventEmitter {
         : verbose === true
         ? {}
         : verbose;
+  }
+
+  public sendAsync(): void {
+    console.warn(
+      "This method is deprecated and should not be used anymore. Please update the code in order to rely on `request` method instead."
+    );
+    return;
   }
 
   public async request({

--- a/src/providers/wallet-connect-ethereum-provider.ts
+++ b/src/providers/wallet-connect-ethereum-provider.ts
@@ -1,0 +1,101 @@
+import EventEmitter from "events";
+import { Provider, VerboseArgs } from "./provider";
+
+type ProviderConstructorArgs = {
+  verbose?: VerboseArgs;
+};
+
+type ConnectionStatus = "notConnected" | "connected" | "connecting";
+
+export class WalletConnectEthereumProvider extends Provider {
+  public events: EventEmitter;
+  public namespace = "eip155";
+  public accounts: string[] = [];
+  public chainId = 1;
+
+  private connectionStatus: ConnectionStatus = "notConnected";
+
+  constructor({ verbose }: ProviderConstructorArgs) {
+    super({
+      verbose,
+      ethTestingProviderType: "WalletConnect-EthereumProvider",
+    });
+
+    this.events = this;
+
+    this.on("chainChanged", (chainId: string | number) => {
+      this.chainId = Number(chainId);
+    });
+    this.on("accountsChanged", (accounts: string[]) => {
+      if (accounts.length === 0) {
+        this.connectionStatus = "notConnected";
+      }
+      this.accounts = accounts;
+    });
+  }
+
+  static async init(mockProviderOpts: ProviderConstructorArgs) {
+    return new WalletConnectEthereumProvider(mockProviderOpts);
+  }
+
+  get connected(): boolean {
+    return this.connectionStatus === "connected";
+  }
+
+  get connecting(): boolean {
+    return this.connectionStatus === "connecting";
+  }
+
+  public async request({
+    method,
+    params = [] as unknown[],
+  }: {
+    method: string;
+    params?: unknown[];
+  }) {
+    const res = await super.request({ method, params });
+    if (method === "eth_chainId") {
+      const chainId = Number(res);
+      if (!isNaN(chainId)) {
+        this.chainId = Number(res);
+      }
+    }
+    if (method === "eth_accounts") {
+      if (Array.isArray(res)) {
+        this.accounts = res as string[];
+      }
+    }
+    return res;
+  }
+
+  public async enable(): Promise<string[]> {
+    const accounts = (await this.request({
+      method: "eth_requestAccounts",
+      params: [],
+    })) as string[];
+    this.accounts = accounts;
+    return accounts;
+  }
+
+  public async connect(_?: any): Promise<void> {
+    const accounts = (await this.request({
+      method: "eth_requestAccounts",
+      params: [],
+    })) as string[];
+    this.accounts = accounts;
+  }
+
+  public async disconnect(): Promise<void> {
+    this.chainId = 1;
+    this.accounts = [];
+    this.connectionStatus = "notConnected";
+  }
+
+  get isWalletConnect() {
+    return true;
+  }
+
+  get session() {
+    throw new Error("Session is not implemented.");
+  }
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -5,6 +5,7 @@ import {
   CoinbaseProvider,
   VerboseArgs,
   ProviderType,
+  WalletConnectEthereumProvider,
 } from "./providers";
 import { TestingUtils } from "./testing-utils";
 
@@ -35,6 +36,8 @@ export function generateTestingUtils({
       ? new CoinbaseProvider({ verbose })
       : providerType === "WalletConnect"
       ? new WalletConnectProvider({ verbose })
+      : providerType === "WalletConnect-EthereumProvider"
+      ? new WalletConnectEthereumProvider({ verbose })
       : new Provider({ verbose, ethTestingProviderType: "default" });
 
   const testingUtils = new TestingUtils(provider);

--- a/src/testing-utils/contract-utils.ts
+++ b/src/testing-utils/contract-utils.ts
@@ -174,7 +174,8 @@ export class ContractUtils<
     const isWalletProvider =
       this.ethTestingProviderType === "MetaMask" ||
       this.ethTestingProviderType === "Coinbase" ||
-      this.ethTestingProviderType === "WalletConnect";
+      this.ethTestingProviderType === "WalletConnect" ||
+      this.ethTestingProviderType === "WalletConnect-EthereumProvider";
     if (isWalletProvider) {
       const accountMock =
         this.mockManager.findUnconditionalPersistentMock("eth_accounts");


### PR DESCRIPTION
## Summary

A mock `EthereumProvider` of `Wallet Connect` has been implemented. It represents the migration from the `Web3Provider` of Wallet Connect V1 to the encouraged [Ethereum Provider](https://github.com/WalletConnect/walletconnect-monorepo/tree/v2.0/providers/ethereum-provider) of Wallet Connect V2, see [migration path](https://docs.walletconnect.com/2.0/advanced/migrating-from-v1.0).

Resolves #64 