### PR TITLE
fix: update specified engines

### DIFF
--- a/.changeset/polite-elephants-drum.md
+++ b/.changeset/polite-elephants-drum.md
@@ -1,0 +1,5 @@
+---
+"eth-testing": patch
+---
+
+Update engines

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       "turbo": "latest"
     },
     "engines": {
-      "node": ">=14.0.0"
+      "npm": ">=6.0.0",
+      "node": ">=16.0.0"
     },
     "dependencies": {
       "@changesets/cli": "^2.26.0"

--- a/packages/eth-testing/package.json
+++ b/packages/eth-testing/package.json
@@ -49,28 +49,17 @@
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.9.0",
-    "husky": "^4.3.7",
-    "lint-staged": "^10.5.3",
     "prettier": "^2.2.1",
     "semantic-release": "^18.0.1",
     "ts-jest": "^28.0.2",
     "tsup": "^6.6.3",
     "typescript": "^4.9.5"
   },
-  "lint-staged": {
-    "src/**/*.{ts,tsx,js,jsx}": [
-      "eslint --max-warnings=0"
-    ],
-    "src/**/*.{ts,tsx,js,jsx,json,css,md,yml,yaml}": [
-      "prettier --write"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "publishConfig": {
     "access": "public"
-}
+  },
+  "engines": {
+    "npm": ">=6.0.0",
+    "node": ">=16.0.0"
+  }
 }


### PR DESCRIPTION
## Summary

The engines in `package.json` are updated to `node >= 16` and `npm >= 6`